### PR TITLE
.textlintrcの例示のフォーマットを調整

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,8 @@
 
 ```js
 {
-    "rules"
-:
-    {
-        "no-double-negative-ja"
-    :
-        true
+    "rules": {
+        "no-double-negative-ja": true
     }
 }
 ```


### PR DESCRIPTION
他のルールと同じようなフォーマットに揃える。

参考
https://github.com/textlint-ja/textlint-rule-no-doubled-joshi?tab=readme-ov-file#usage
https://github.com/textlint-ja/textlint-rule-no-mix-dearu-desumasu?tab=readme-ov-file#usage